### PR TITLE
Fix config.h include for libftdi defines

### DIFF
--- a/src/examples/bitbang.c
+++ b/src/examples/bitbang.c
@@ -1,3 +1,4 @@
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpsse.h>

--- a/src/examples/ds1305.c
+++ b/src/examples/ds1305.c
@@ -1,3 +1,4 @@
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpsse.h>

--- a/src/examples/gpio.c
+++ b/src/examples/gpio.c
@@ -1,3 +1,4 @@
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpsse.h>

--- a/src/examples/i2ceeprom.c
+++ b/src/examples/i2ceeprom.c
@@ -1,7 +1,7 @@
 /* 
  * Example code to read the contents of an I2C EEPROM chip.
  */
-
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpsse.h>

--- a/src/examples/spiflash.c
+++ b/src/examples/spiflash.c
@@ -1,3 +1,4 @@
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpsse.h>

--- a/src/examples/spiflashfast.c
+++ b/src/examples/spiflashfast.c
@@ -2,7 +2,7 @@
  * Example code of using the low-latency FastRead and FastWrite functions (SPI and C only).
  * Contrast to spiflash.c.
  */
-
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpsse.h>

--- a/src/fast.c
+++ b/src/fast.c
@@ -7,6 +7,7 @@
  */
 
 #include <string.h>
+#include "config.h"
 #include "mpsse.h"
 #include "support.h"
 

--- a/src/mpsse.c
+++ b/src/mpsse.c
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <time.h>
 
+#include "config.h"
 #include "mpsse.h"
 #include "support.h"
 

--- a/src/mpsse.c
+++ b/src/mpsse.c
@@ -12,7 +12,6 @@
 
 #include "mpsse.h"
 #include "support.h"
-#include "config.h"
 
 /* List of known FT2232-based devices */
 struct vid_pid supported_devices[] = {

--- a/src/mpsse.h
+++ b/src/mpsse.h
@@ -2,6 +2,7 @@
 #define _LIBMPSSE_H_
 
 #include <stdint.h>
+#include "config.h"
 
 #if HAVE_LIBFTDI1 == 1
 #include <libftdi1/ftdi.h>

--- a/src/mpsse.h
+++ b/src/mpsse.h
@@ -2,7 +2,6 @@
 #define _LIBMPSSE_H_
 
 #include <stdint.h>
-#include "config.h"
 
 #if HAVE_LIBFTDI1 == 1
 #include <libftdi1/ftdi.h>

--- a/src/support.c
+++ b/src/support.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "config.h"
 #include "mpsse.h"
 #include "support.h"
 


### PR DESCRIPTION
Move config.h include to mpsse.h so that the defines in the config file can be referenced

fixes #13