### PR TITLE
Clean up libftdi dependencies

### DIFF
--- a/src/examples/bitbang.c
+++ b/src/examples/bitbang.c
@@ -1,7 +1,7 @@
-#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpsse.h>
+#include <unistd.h>
 
 int main(void)
 {
@@ -17,7 +17,7 @@ int main(void)
 			PinHigh(io, 0);
 			printf("Pin 0 is: %d\n", PinState(io, 0, -1));
 			sleep(1);
-			
+
 			PinLow(io, 0);
 			printf("Pin 0 is: %d\n", PinState(io, 0, -1));
 			sleep(1);

--- a/src/examples/ds1305.c
+++ b/src/examples/ds1305.c
@@ -1,4 +1,3 @@
-#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpsse.h>
@@ -9,20 +8,20 @@ int main(void)
 	struct mpsse_context *ds1305 = NULL;
 	int sec = 0, min = 0, retval = EXIT_FAILURE;
 	char *control = NULL, *seconds = NULL, *minutes = NULL;
-	
+
 	if((ds1305 = MPSSE(SPI3, ONE_HUNDRED_KHZ, MSB)) != NULL && ds1305->open)
 	{
 		SetCSIdle(ds1305, 0);
 
 		printf("%s initialized at %dHz (SPI mode 3)\n", GetDescription(ds1305), GetClock(ds1305));
-		
+
 		Start(ds1305);
 		Write(ds1305, "\x0F", 1);
 		control = Read(ds1305, 1);
 		Stop(ds1305);
-		
+
 		control[0] &= ~0x80;
-		
+
 		Start(ds1305);
 		Write(ds1305, "\x8F", 1);
 		Write(ds1305, control, 1);
@@ -52,7 +51,7 @@ int main(void)
 
 			free(minutes);
 			free(seconds);
-		}	
+		}
 	}
 	else
 	{

--- a/src/examples/gpio.c
+++ b/src/examples/gpio.c
@@ -1,7 +1,7 @@
-#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpsse.h>
+#include <unistd.h>
 
 int main(void)
 {
@@ -9,7 +9,7 @@ int main(void)
 	int i = 0, retval = EXIT_FAILURE;
 
 	io = MPSSE(GPIO, 0, 0);
-	
+
 	if(io && io->open)
 	{
 		for(i=0; i<10; i++)
@@ -17,19 +17,19 @@ int main(void)
 			PinHigh(io, GPIOL0);
 			printf("GPIOL0 State: %d\n", PinState(io, GPIOL0, -1));
 			sleep(1);
-			
+
 			PinLow(io, GPIOL0);
 			printf("GPIOL0 State: %d\n", PinState(io, GPIOL0, -1));
 			sleep(1);
 		}
-	
+
 		retval = EXIT_SUCCESS;
 	}
 	else
 	{
 		printf("Failed to open MPSSE: %s\n", ErrorString(io));
 	}
-		
+
 	Close(io);
 
 	return retval;

--- a/src/examples/i2ceeprom.c
+++ b/src/examples/i2ceeprom.c
@@ -1,7 +1,6 @@
-/* 
+/*
  * Example code to read the contents of an I2C EEPROM chip.
  */
-#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpsse.h>
@@ -21,8 +20,8 @@ int main(void)
 	if((eeprom = MPSSE(I2C, FOUR_HUNDRED_KHZ, MSB)) != NULL && eeprom->open)
 	{
 		printf("%s initialized at %dHz (I2C)\n", GetDescription(eeprom), GetClock(eeprom));
-	
-		/* Write the EEPROM start address */	
+
+		/* Write the EEPROM start address */
 		Start(eeprom);
 		Write(eeprom, WCMD, sizeof(WCMD) - 1);
 
@@ -50,7 +49,7 @@ int main(void)
 
 					free(data);
 				}
-	
+
 				/* Tell libmpsse to send NACKs after reading data */
 				SendNacks(eeprom);
 

--- a/src/examples/spiflash.c
+++ b/src/examples/spiflash.c
@@ -1,4 +1,3 @@
-#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpsse.h>
@@ -13,17 +12,17 @@ int main(void)
 	char *data = NULL, *data1 = NULL;
 	int retval = EXIT_FAILURE;
 	struct mpsse_context *flash = NULL;
-	
+
 	if((flash = MPSSE(SPI0, TWELVE_MHZ, MSB)) != NULL && flash->open)
 	{
 		printf("%s initialized at %dHz (SPI mode 0)\n", GetDescription(flash), GetClock(flash));
-		
+
 		Start(flash);
 		Write(flash, RCMD, sizeof(RCMD) - 1);
 		data = Read(flash, SIZE);
 		data1 = Read(flash, SIZE);
 		Stop(flash);
-		
+
 		if(data)
 		{
 			fp = fopen(FOUT, "wb");
@@ -32,7 +31,7 @@ int main(void)
 				fwrite(data, 1, SIZE, fp);
 				fwrite(data1, 1, SIZE, fp);
 				fclose(fp);
-				
+
 				printf("Dumped %d bytes to %s\n", SIZE, FOUT);
 				retval = EXIT_SUCCESS;
 			}

--- a/src/examples/spiflashfast.c
+++ b/src/examples/spiflashfast.c
@@ -2,7 +2,6 @@
  * Example code of using the low-latency FastRead and FastWrite functions (SPI and C only).
  * Contrast to spiflash.c.
  */
-#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpsse.h>
@@ -17,16 +16,16 @@ int main(void)
 	char data[SIZE] = { 0 };
 	int retval = EXIT_FAILURE;
 	struct mpsse_context *flash = NULL;
-	
+
 	if((flash = MPSSE(SPI0, TWELVE_MHZ, MSB)) != NULL && flash->open)
 	{
 		printf("%s initialized at %dHz (SPI mode 0)\n", GetDescription(flash), GetClock(flash));
-		
+
 		Start(flash);
 		FastWrite(flash, RCMD, sizeof(RCMD) - 1);
 		FastRead(flash, data, SIZE);
 		Stop(flash);
-		
+
 		if(data)
 		{
 			fp = fopen(FOUT, "wb");
@@ -34,7 +33,7 @@ int main(void)
 			{
 				fwrite(data, 1, SIZE, fp);
 				fclose(fp);
-				
+
 				printf("Dumped %d bytes to %s\n", SIZE, FOUT);
 				retval = EXIT_SUCCESS;
 			}

--- a/src/mpsse.h
+++ b/src/mpsse.h
@@ -3,12 +3,6 @@
 
 #include <stdint.h>
 
-#if HAVE_LIBFTDI1 == 1
-#include <libftdi1/ftdi.h>
-#else
-#include <ftdi.h>
-#endif
-
 #define MPSSE_OK		0
 #define MPSSE_FAIL		-1
 
@@ -39,14 +33,17 @@
 
 #define NULL_CONTEXT_ERROR_MSG	"NULL MPSSE context pointer!"
 
-/* FTDI interfaces */
+/* FTDI interfaces
+ * The values in this enum match those defined in ftdi.h and libftdi1/ftdi.h,
+ * do not modify them.
+ */
 enum interface
 {
-	IFACE_ANY	= INTERFACE_ANY,
-	IFACE_A 	= INTERFACE_A,
-	IFACE_B		= INTERFACE_B,
-	IFACE_C		= INTERFACE_C,
-	IFACE_D		= INTERFACE_D
+	IFACE_ANY,
+	IFACE_A,
+	IFACE_B,
+	IFACE_C,
+	IFACE_D,
 };
 
 /* Common clock rates */
@@ -148,7 +145,7 @@ struct vid_pid
 struct mpsse_context
 {
 	char *description;
-	struct ftdi_context ftdi;
+	struct ftdi_context* ftdi;
 	enum modes mode;
 	enum low_bits_status status;
 	int flush_after_read;

--- a/src/support.c
+++ b/src/support.c
@@ -9,6 +9,12 @@
 #include <string.h>
 
 #include "config.h"
+#if HAVE_LIBFTDI1 == 1
+#include <libftdi1/ftdi.h>
+#else
+#include <ftdi.h>
+#endif
+
 #include "mpsse.h"
 #include "support.h"
 
@@ -17,15 +23,15 @@
 /* Write data to the FTDI chip */
 int raw_write(struct mpsse_context *mpsse, unsigned char *buf, int size)
 {
-        int retval = MPSSE_FAIL;
+	int retval = MPSSE_FAIL;
 
-        if(mpsse->mode)
+	if(mpsse->mode)
 	{
-		if(ftdi_write_data(&mpsse->ftdi, buf, size) == size)
-        	{
-                	retval = MPSSE_OK;
+		if(ftdi_write_data(mpsse->ftdi, buf, size) == size)
+		{
+			retval = MPSSE_OK;
 		}
-        }
+	}
 
 	return retval;
 }
@@ -40,7 +46,7 @@ int raw_read(struct mpsse_context *mpsse, unsigned char *buf, int size)
 	{
 		while((n < size) && (retry -- > 0))
 		{
-			r = ftdi_read_data(&mpsse->ftdi, buf, size);
+			r = ftdi_read_data(mpsse->ftdi, buf, size);
 			if(r < 0) break;
 			n += r;
 		}
@@ -52,7 +58,7 @@ int raw_read(struct mpsse_context *mpsse, unsigned char *buf, int size)
 			 *
 			 * Is this needed anymore? It slows down repetitive read operations by ~8%.
 			 */
-			ftdi_usb_purge_rx_buffer(&mpsse->ftdi);
+			ftdi_usb_purge_rx_buffer(mpsse->ftdi);
 		}
 	}
 
@@ -64,8 +70,8 @@ void set_timeouts(struct mpsse_context *mpsse, int timeout)
 {
 	if(mpsse->mode)
         {
-                mpsse->ftdi.usb_read_timeout = timeout;
-                mpsse->ftdi.usb_write_timeout = timeout;
+                mpsse->ftdi->usb_read_timeout = timeout;
+                mpsse->ftdi->usb_write_timeout = timeout;
         }
 
 	return;


### PR DESCRIPTION
This removes dependency on libftdi/libftdi1 include file from mpsse.h

The user still needs to know which library to link against, but issue is left for some other time.