### PR TITLE
Initial support for fetching/maintaining ACBUS pin state

### DIFF
--- a/src/mpsse.h
+++ b/src/mpsse.h
@@ -1,6 +1,10 @@
 #ifndef _LIBMPSSE_H_
 #define _LIBMPSSE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 
 #if HAVE_LIBFTDI1 == 1
@@ -224,5 +228,8 @@ int FastRead(struct mpsse_context *mpsse, char *data, size_t size);
 int FastTransfer(struct mpsse_context *mpsse, const char *wdata, char *rdata, size_t size);
 #endif
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/support.c
+++ b/src/support.c
@@ -228,6 +228,16 @@ int set_bits_high(struct mpsse_context *mpsse, int port)
 	return raw_write(mpsse, (unsigned char *) &buf, sizeof(buf));
 }
 
+int get_bits_high(struct mpsse_context *mpsse, uint8_t* value) {
+	unsigned char buf[] = { GET_BITS_HIGH };
+
+	int res = raw_write(mpsse, buf, sizeof(buf));
+	if (res != MPSSE_OK) return res;
+
+	if (raw_read(mpsse, value, 1) != 1) return MPSSE_FAIL;
+	return MPSSE_OK;
+}
+
 /* Set the GPIO pins high/low */
 int gpio_write(struct mpsse_context *mpsse, int pin, int direction)
 {

--- a/src/support.h
+++ b/src/support.h
@@ -11,6 +11,7 @@ uint32_t div2freq(uint32_t system_clock, uint16_t div);
 unsigned char *build_block_buffer(struct mpsse_context *mpsse, uint8_t cmd, const unsigned char *data, size_t size, int *buf_size);
 int set_bits_high(struct mpsse_context *mpsse, int port);
 int set_bits_low(struct mpsse_context *mpsse, int port);
+int get_bits_high(struct mpsse_context *mpsse, uint8_t* value);
 int gpio_write(struct mpsse_context *mpsse, int pin, int direction);
 int is_valid_context(struct mpsse_context *mpsse);
 


### PR DESCRIPTION
Besides more complete set of functions (there is set_bits_high and not get_bits_high), this is a pre-requisite for multi-session GPIO: https://github.com/twasilczyk/libmpsse/commit/23b9e67b6b506d8375a133ec89cd3606fed23a1e

I didn't implement get_bits_low because I don't have hardware to test it with.